### PR TITLE
docs: fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository contains the source for Firebase Extensions produced by the Google Maps Platform team.
 
-To view more details about them including stats, configuration, latest versions, and to install them go to [extensions.dev](https://extensions.dev/extensions?provider=google-maps-platform).
+To view more details about them including stats, configuration, latest versions, and to install them go to [extensions.dev](https://extensions.dev/extensions?provider=googlemapsplatform).


### PR DESCRIPTION
Our publisher tag is `googlemapsplatform` but it would be nice if `google-maps-platform` also worked! Until then, here's a fix.
